### PR TITLE
Bugfixes for demos

### DIFF
--- a/scripted/demos/nobelists/nobelists.html
+++ b/scripted/demos/nobelists/nobelists.html
@@ -4,8 +4,9 @@
     <link rel="stylesheet" href="http://www.simile-widgets.org/styles/common.css" type="text/css" />
     <link href="nobelists.js" type="application/json" rel="exhibit-data" />
 
-    <script src="http://api.simile-widgets.org/exhibit/3.0.0rc1/exhibit-api.js"></script>
-    <script src="http://api.simile-widgets.org/exhibit/3.0.0rc1/extensions/time/time-extension.js"></script>
+    <script src="http://code.jquery.com/jquery-1.7.2.min.js"></script>
+    <script src="../../api/exhibit-api.js"></script>
+    <script src="../../api/extensions/time/time-extension.js"></script>
     
     <style>
         body {

--- a/scripted/demos/senate/senate.html
+++ b/scripted/demos/senate/senate.html
@@ -7,7 +7,7 @@
     <link href="senate-committees.js" type="application/json" rel="exhibit-data" />
     <link href="senate-bills.js" type="application/json" rel="exhibit-data" />
 
-    <script src="http://api.simile-widgets.org/exhibit/3.0.0rc1/exhibit-api.js"></script>
+    <script src="../../api/exhibit-api.js?bundle=false"></script>
     
     <script type="text/javascript">
         var rowStyler = function(item, database, tr) {

--- a/scripted/src/scripts/exhibit.js
+++ b/scripted/src/scripts/exhibit.js
@@ -377,7 +377,7 @@ Exhibit._Impl.prototype.configureFromDOM = function(root) {
 
     if (controlPanelElmts.length === 0) {
         panel = Exhibit.ControlPanel.createFromDOM(
-            $("<div>").prependTo(document.body),
+	    $("<div>").prependTo(document.body).get(0),
             null,
             uiContext
         );

--- a/scripted/src/scripts/ui/views/ordered-view-frame.js
+++ b/scripted/src/scripts/ui/views/ordered-view-frame.js
@@ -1006,8 +1006,11 @@ Exhibit.OrderedViewFrame.renderPageLinks = function(parentElmt, page, pageCount,
             .attr("class", "exhibit-collectionView-pagingControls-page");
         $(parentElmt).append(elmt);
         
-        a = $("<a>")
-            .html(label)
+        a = $("<a>");
+	//don't chain; if Exhibit.ViewUtil...(index) returns
+	//undefined, then attr will act is if it has no second arg
+	//and return the value of the attribute, not the dom element
+	a.html(label)
             .attr("href", "#")
             .attr("title", Exhibit.ViewUtilities.makePagingLinkTooltip(index));
         elmt.append(a);


### PR DESCRIPTION
I've got both nobelists and senate demos working again.

senate was causing ordered-view-frame.js to jquery-chain
.attr('foo',undefined) which unhelpfully returns the value of the
'foo' attribute instead of the jquery object.
nobelists is hitting a load-order bug and failing to load timeline;
i've temporarily fixed it by explicitly loading jquery in nobelist.html

The same .attr bug occured when I tried to leave out the timeline extension (because a view ended up returning null).  Would it be worth implementing a setAttr method that is guaranteed to return the object even if the attribute value is null?
