### PR TITLE
Fix a bug that prevented IE9 from loading the json.

### DIFF
--- a/scripted/src/scripts/util/persistence.js
+++ b/scripted/src/scripts/util/persistence.js
@@ -43,7 +43,10 @@ Exhibit.Persistence.getBaseURL = function(url) {
                 url = url2 + url;
             }
         }
-        
+        i = url.indexOf("#");
+        if (i >= 0) {
+            url = url.substr(0, i);
+        }
         i = url.lastIndexOf("/");
         if (i < 0) {
             return "";


### PR DESCRIPTION
IE 9 included a slash in the hash which broke the getBaseURL method. This commit strips the hash before stripping everything after the last slash.
