### PR TITLE
Corrected LABjs usage and fixed timeline load-order problems.

### DIFF
--- a/scripted/src/exhibit-api.js
+++ b/scripted/src/exhibit-api.js
@@ -360,6 +360,42 @@ Exhibit.includeCssFiles = function(doc, urlPrefix, filenames) {
 
 /**
  * @static
+ * @param {Object} scr
+ * @param {String} prefix
+ */
+Exhibit.includeScript = function(scr, prefix) {
+    if (typeof(prefix) === "undefined") {
+	prefix = Exhibit.urlPrefix;
+    }
+    if (Exhibit.loader === null) {
+	$LAB.setGlobalDefaults({
+		AlwaysPreserveOrder: true,
+		UseLocalXHR: false,
+		AllowDuplicates: false
+	    });
+	Exhibit.loader = $LAB.setOptions({"AlwaysPreserveOrder": true});
+    }
+
+    if (typeof(scr) === "string") {
+	if (scr.indexOf("/") !== 0 &&
+	    (scr.indexOf(":") <= 0 || scr.indexOf("//") <= 0)) {
+	    scr = prefix + scr;
+	}
+	Exhibit.loader = Exhibit.loader.script(scr);
+    } else if (typeof(scr) === "function") {
+	Exhibit.loader = Exhibit.loader.wait(scr);
+    } else {
+	if (Exhibit.Debug) {
+	    Exhibit.Debug.warn(Exhibit._("%general.error.unloadableScript",
+					 typeof(scr)));
+	} else {
+	    throw new Error("error loading scripts");
+	}
+    }
+};
+
+/**
+ * @static
  * @param {Document} doc
  * @param {String} urlPrefix
  * @param {Array} filenames
@@ -367,7 +403,7 @@ Exhibit.includeCssFiles = function(doc, urlPrefix, filenames) {
 Exhibit.includeJavascriptFiles = function(doc, urlPrefix, filenames) {
     var i;
     for (i = 0; i < filenames.length; i++) {
-        Exhibit.loader.script(urlPrefix + filenames[i]);
+        Exhibit.includeScript(filenames[i],urlPrefix);
     }
 };
 
@@ -469,21 +505,14 @@ Exhibit.load = function() {
         docHead.appendChild(style);
     }
 
-    $LAB.setGlobalDefaults({
-        AlwaysPreserveOrder: true,
-        UseLocalXHR: false,
-        AllowDuplicates: false
-    });
-    Exhibit.loader = $LAB.setOptions({"AlwaysPreserveOrder": true});
-
     for (i in Exhibit._dependencies) {
         if (typeof Exhibit._dependencies[i] === "undefined") {
-            Exhibit.loader.script(Exhibit.urlPrefix + i);
+            Exhibit.includeScript(i);
         } else if (Exhibit._dependencies.hasOwnProperty(i)) {
             dep = Exhibit._dependencies[i].split(".");
             if (dep.length === 1) {
                 if (!Object.prototype.hasOwnProperty.call(window, dep[0])) {
-                    Exhibit.loader.script(Exhibit.urlPrefix + i);
+                    Exhibit.includeScript(i);
                 }
             } else {
                 for (j = 0; j < dep.length; j++) {
@@ -493,7 +522,7 @@ Exhibit.load = function() {
                     }
                     if (!o.hasOwnProperty(dep[j])) {
                         if (j === dep.length - 1) {
-                            Exhibit.loader.script(Exhibit.urlPrefix + i);
+                            Exhibit.includeScript(i);
                         } else {
                             break;
                         }
@@ -505,12 +534,7 @@ Exhibit.load = function() {
 
     scr = Exhibit.scripts;
     for (i = 0; i < scr.length; i++) {
-        if (scr[i].indexOf("/") === 0 ||
-            (scr[i].indexOf(":") > 0 && scr[i].indexOf("//") > 0)) {
-            Exhibit.loader.script(scr[i]);
-        } else {
-            Exhibit.loader.script(Exhibit.urlPrefix + scr[i]);
-        }
+	Exhibit.includeScript(scr[i]);
     }
 };
 

--- a/scripted/src/extensions/time/time-extension.js
+++ b/scripted/src/extensions/time/time-extension.js
@@ -126,5 +126,7 @@
         finishedLoading();
     };
 
-    Exhibit.jQuery(document).one("loadExtensions.exhibit", loader);
+    Exhibit.includeScript(function() {
+	    jQuery(document).one("loadExtensions.exhibit", loader);
+	});
 }());

--- a/scripted/src/locales/en/locale.js
+++ b/scripted/src/locales/en/locale.js
@@ -24,6 +24,7 @@ Exhibit.Localization.importLocale("en", {
     "%general.error.lensSelectorNotFunction": "lensSelector is not a function",
     "%general.error.lensSelectorExpressionNotFunction": "lensSelector expression %1$s is not a function",
     "%general.error.badLensSelectorExpression": "Bad lensSelector expression: %1$s",
+    "%general.error.unloadableScript": "Unable to load script of type %1$s",
 
     "%lens.error.unknownLensType": "Unknown lens type: %1$s",
     "%lens.error.failedToLoad": "Failed to load view template from %1$s\n%2$s",

--- a/scripted/src/scripts/final.js
+++ b/scripted/src/scripts/final.js
@@ -72,7 +72,7 @@ Exhibit.jQuery(document).ready(function() {
         Exhibit.loader.script(Exhibit.jQuery(el).attr("href"));
     });
 
-    Exhibit.loader.wait(function() {
+    Exhibit.includeScript(function() {
         Exhibit.jQuery(document).trigger("registerLocalization.exhibit", Exhibit.staticRegistry);
     });
 });


### PR DESCRIPTION
Based on the setting of the "AlwaysPreserveOrder" option in LABjs, it
appears that the intent was to serialize all script loading in
exhibit.  However, LABjs only guarantees serialization of scripts that
are in the same chain, and Exhibit wasn't chaining its $LAB.script()
calls.

I've introduced a new function, Exhibit.includeScript, in
exhibit-api.js.  It accepts a string (url to be included as a
script) or a function (to be queued for execution after the previous
script loads).  In either case, it serializes all passed in scripts in
the order of invocation of includeScript.

I've modified the timeline extension to make use of the new loading
mechanism, and the timeline in the nobelists example now works.

BUG: because of the polling hack for timeline, it is possible
that on a slow connection the poll will succeed (Timeline is defined)
before all of Timeline is loaded/initialized, which will make Exhibit
choke when it tries to configure the timeline.
