### PR TITLE
2012 08 13 view panel

### DIFF
--- a/scripted/src/scripts/ui/views/view-panel.js
+++ b/scripted/src/scripts/ui/views/view-panel.js
@@ -52,7 +52,7 @@ Exhibit.ViewPanel._registerComponent = function(evt, reg) {
  * @returns {Exhibit.ViewPanel}
  */
 Exhibit.ViewPanel.create = function(configuration, div, uiContext) {
-    var viewPanel, i, viewconfig, viewClass, label, tooltip, id, viewClassName;
+    var viewPanel, i, viewConfig, viewClass, label, tooltip, id, viewClassName;
     viewPanel = new Exhibit.ViewPanel(div, uiContext);
     
     if (typeof configuration.views !== "undefined") {
@@ -120,7 +120,7 @@ Exhibit.ViewPanel.create = function(configuration, div, uiContext) {
  * @returns {Exhibit.ViewPanel}
  */
 Exhibit.ViewPanel.createFromDOM = function(div, uiContext) {
-    var viewPanel, role, viewClass, viewClassName, viewLabel, tooltip, label, id, intialView, n;
+    var viewPanel, role, viewClass, viewClassName, viewLabel, tooltip, label, id, initialView, n;
     viewPanel = new Exhibit.ViewPanel(div, Exhibit.UIContext.createFromDOM(div, uiContext, false));
     
     Exhibit.jQuery(div).children().each(function(index, elmt) {

--- a/scripted/src/scripts/ui/views/view-panel.js
+++ b/scripted/src/scripts/ui/views/view-panel.js
@@ -20,6 +20,7 @@ Exhibit.ViewPanel = function(div, uiContext) {
     this._viewLabels = [];
     this._viewTooltips = [];
     this._viewDomConfigs = [];
+    this._viewDoms = [];
     
     this._viewIndex = 0;
     this._view = null;
@@ -165,6 +166,7 @@ Exhibit.ViewPanel.createFromDOM = function(div, uiContext) {
             viewPanel._viewLabels.push(label);
             viewPanel._viewTooltips.push(tooltip);
             viewPanel._viewDomConfigs.push(this);
+            viewPanel._viewDoms.push(Exhibit.jQuery('<div></div>').appendTo(this));
         }
     });
     
@@ -349,24 +351,22 @@ Exhibit.ViewPanel.prototype._initializeUI = function() {
 Exhibit.ViewPanel.prototype._createView = function() {
     var viewContainer, viewDiv, index, context;
     viewContainer = this._dom.getViewContainer();
-    Exhibit.jQuery(viewContainer).empty();
-
-    viewDiv = Exhibit.jQuery("<div>");
-    Exhibit.jQuery(viewContainer).append(viewDiv);
     
     index = this._viewIndex;
+    viewDiv = this._viewDoms[index] || viewContainer;
+    viewDiv.show().parent().show();
     context = this._uiContextCache[index] || this._uiContext;
     try {
         if (this._viewDomConfigs[index] !== null) {
             this._view = this._viewConstructors[index].createFromDOM(
                 this._viewDomConfigs[index],
-                viewContainer, 
+                viewDiv, 
                 context
             );
         } else {
             this._view = this._viewConstructors[index].create(
                 this._viewConfigs[index],
-                viewContainer, 
+                viewDiv, 
                 context
             );
         }


### PR DESCRIPTION
Modified viewpanel to render views inside the tags that specify them.

Previously, views were rendered in a separately created "view container" that was not a child of the tag specifying the view. Thus, attributes specified on the view tag (e.g. classes for styling) would not apply to the rendered view.  Which made it more difficult for an author to style those views.  In the new version, the view container is placed inside the tag that specified the view.

If the selected view was defined programmatically, rather than by a tag, then the view container is placed as an immediate child of the view panel tag.

The current solution is imperfect.  To render a view, the viewpanel empties the target div, which destroys contextual information such as lenses intended for the view.  For standalone views this is ok, as the view is rendered only once.  However, the viewpanel re-creates a view each time that view is selected; the
second rendering will no longer have the context.  To circumvent this problem, a new div is created inside the view tag to hold the rendered view.  Thus, when it is emptied for the next rendering, the remaining content of the view tag is undisturbed.

On the downside, this means that standalone views render in a slightly different way than views in viewpanels---those in viewpanels are nested inside a view container that is not present in standalone views.
However, this is still a significant improvement over the previous approach, where the rendered view was not inside the viewtag at all. 

Longer-term, it seems beneficial for every view to render its content inside a newly-created, nested view container div.  This would provide consistency while still shielding the rendering and the original
specification-content of the view tag from each other.

Note jslint is throwing tons of errors, but not from my new code.  In particular, the .create method (which exhibit never uses) is clearly broken since it references an undefined variable (view).  
