### PR TITLE
Exhibit should not jQuery.noConflict() if jQuery was previously set.

### DIFF
--- a/scripted/src/exhibit-api.js
+++ b/scripted/src/exhibit-api.js
@@ -26,6 +26,12 @@ var Exhibit = {
     locales: [],
 
     /**
+       Whether to release jQuery after loading exhibit
+     **/
+    jQueryNoConflict: typeof(jQuery) === 'undefined',
+
+
+    /**
      * Whether Exhibit has been loaded yet.
      */
     loaded: false,

--- a/scripted/src/scripts/exhibit.js
+++ b/scripted/src/scripts/exhibit.js
@@ -7,7 +7,11 @@
 /**
  * Starting using Exhibit.jQuery instead of jQuery or $
  */
-Exhibit.jQuery = jQuery.noConflict();
+
+Exhibit.jQuery = jQuery;
+if (Exhibit.jQueryNoConflict) {
+    jQuery.noConflict();
+}
 
 /**
  * @static


### PR DESCRIPTION
Exhibit was already _using_ a preexisting jquery instead of loading
jquery again.  However, in such a case Exhibit should _not_ call
jQuery.noConflict(), since that would taint the state that existed
prior to Exhibit loading.
