### PR TITLE
two bugfixes.

### DIFF
--- a/scripted/src/extensions/time/time-extension.js
+++ b/scripted/src/extensions/time/time-extension.js
@@ -126,5 +126,7 @@
         finishedLoading();
     };
 
-    Exhibit.jQuery(document).one("loadExtensions.exhibit", loader);
+    Exhibit.wait(function() {
+        Exhibit.jQuery(document).one("loadExtensions.exhibit", loader);
+	});
 }());

--- a/scripted/src/scripts/ui/facets/facet.js
+++ b/scripted/src/scripts/ui/facets/facet.js
@@ -227,7 +227,7 @@ Exhibit.Facet = function(key, div, uiContext) {
 Exhibit.Facet._registryKey = "facet";
 
 Exhibit.Facet._settingSpecs = {
-    "facetLabel":       { "type": "text" },
+    "facetLabel":       { "type": "text" }
 };
 
 /**


### PR DESCRIPTION
- a comma in facet.js that breaks IE
- time-extension.js was invoking Exhibit.jQuery before jQuery got set;
  I added an Exhibit.wait() so it would not happen.
