### PR TITLE
Fix URL formatting, minor typo for image tooltips

### DIFF
--- a/scripted/src/scripts/ui/formatter.js
+++ b/scripted/src/scripts/ui/formatter.js
@@ -268,7 +268,7 @@ Formatter._ImageFormatter.prototype.format = function(value, appender) {
     
     if (this._tooltip !== null) {
         if (typeof this._tooltip === "string") {
-            img.attr("title", this._tootlip);
+            img.attr("title", this._tooltip);
         } else {
             img.attr("title",
                      this._tooltip.evaluateSingleOnItem(
@@ -304,7 +304,7 @@ Formatter._URLFormatter = function(uiContext) {
  * @param {Function} appender
  */
 Formatter._URLFormatter.prototype.format = function(value, appender) {
-    var a = $("a").attr("href", value).html(value);
+    var a = $("<a>").attr("href", value).html(value);
     
     if (this._target !== null) {
         a.attr("target", this._target);


### PR DESCRIPTION
Fixing some minor typo's from viewshare integration.  The tootlip thing is obvious, but the 'a' tag wrapper was stomping on every link in the page when formatting a URL.

I'm assuming you want pull requests to requirejs rather than master.
